### PR TITLE
Bug-fixing: auto scroll, #89, #86

### DIFF
--- a/src/components/layouts/pages/inspect/pdfDocument/PdfDocument.js
+++ b/src/components/layouts/pages/inspect/pdfDocument/PdfDocument.js
@@ -390,7 +390,9 @@ class PdfDocument extends React.PureComponent {
         if (hoveredKey !== this.state.hoveredKey) {
             this.redrawCanvasByPage(pageIndex);
             if (this.props.selectedCheck) {
-                this.selectRect(this.state.errorsRects[this.props.selectedCheck]);
+                if (pageIndex === this.state.errorsRects[this.props.selectedCheck]?.pageIndex) {
+                    this.selectRect(this.state.errorsRects[this.props.selectedCheck]);
+                }
             }
 
             if (hoveredKey) {

--- a/src/components/layouts/pages/inspect/pdfDocument/PdfDocument.js
+++ b/src/components/layouts/pages/inspect/pdfDocument/PdfDocument.js
@@ -198,6 +198,7 @@ class PdfDocument extends React.PureComponent {
             bboxByPage: newBboxByPage,
             canvasPages: pagesArray,
             pagesMap: this.getPages(),
+            annotationsByPage,
         });
 
         setTimeout(() => {


### PR DESCRIPTION
Part of #54 : Added auto scroll on select from pdf check
closes #89 : Fixed error of annotations on first page
closes #86 : Fixed canvas redrawing on mouseMove event